### PR TITLE
add case default to avoid latch

### DIFF
--- a/hdl/iwls05/faraday/rtl/DMA/hdl/dma_chsel.v
+++ b/hdl/iwls05/faraday/rtl/DMA/hdl/dma_chsel.v
@@ -855,6 +855,7 @@ case(fix_pri_sel)
 'h1: arb_ch_sel = gnt_p1; 
 'h2: arb_ch_sel = gnt_p2; 
 'h3: arb_ch_sel = gnt_p3; 
+default: arb_ch_sel = 0;
 endcase 
 
 


### PR DESCRIPTION
Hi~

I found that there is a `case` statement missing the `default` description in the `dma_chsel` module, which leads to a latch generation in the synthesis process. I add a default statement to fix the bug.

Thanks~