### PR TITLE
bugfix: width mismatch on port 'T_PLLsel' of reference to 'PLL' in 'TOP'

### DIFF
--- a/hdl/iwls05/faraday/rtl/DSP/hdl/TOP/t_top.v
+++ b/hdl/iwls05/faraday/rtl/DSP/hdl/TOP/t_top.v
@@ -601,7 +601,7 @@ dsp (
 `ifdef FD_EVB
 `else
 PLL pll (
-.T_PLLsel(T_PLLsel[3:0]),
+.T_PLLsel(T_PLLsel[0]),
 .CLKI(T_CLKI_OSC),
 .CLKO(T_CLKI_PLL),
 .PDN(XTALoffn),


### PR DESCRIPTION
Hi~

I fix a width mismatch error for iwls05/faraday/DSP block on Design Compiler tool.

Thanks~